### PR TITLE
Update Laravel version constraint to ^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "php": "^7.2",
         "doctrine/dbal": "^2.9",
         "fideloper/proxy": "^4.0",
-        "laravel/framework": "6.3.*",
+        "laravel/framework": "^6.0",
         "laravel/socialite": "^4.2",
         "laravel/tinker": "^1.0",
         "ext-zip": "*"


### PR DESCRIPTION
Now that Laravel has started using semantic versioning. The version constraint should be different that it used to before v6 :)